### PR TITLE
travis: initial CI recipe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+notifications:
+  email: false
+
+sudo: true
+
+language: python
+
+cache:
+  - pip
+
+python:
+  - 2.7
+
+services:
+  - docker
+
+before_install:
+  - travis_retry pip install yadage
+
+install:
+  - docker build -t worldpopulation .
+
+script:
+  - yadage-validate world_population_analysis.yaml | grep -q 'workflow validates'
+  - docker run -v `pwd`:/code -i -t --rm worldpopulation jupyter nbconvert world_population_analysis.ipynb
+  - ls -l world_population_analysis.html

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,15 @@
  Reusable analysis example - "world population"
 ================================================
 
+.. image:: https://img.shields.io/travis/reanahub/reana-demo-worldpopulation.svg
+   :target: https://travis-ci.org/reanahub/reana-demo-worldpopulation
+
+.. image:: https://badges.gitter.im/Join%20Chat.svg
+   :target: https://gitter.im/reanahub/reana?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge
+
+.. image:: https://img.shields.io/github/license/reanahub/reana-demo-worldpopulation.svg
+   :target: https://github.com/reanahub/reana-demo-worldpopulation/blob/master/COPYING
+
 About
 =====
 


### PR DESCRIPTION
* Adds the initial Travis CI recipe that builds the "world population" example
  analysis Docker image and tests whether it works OK.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>