### PR TITLE
yadage: Slurm compute backend example

### DIFF
--- a/reana-yadage-slurmcern.yaml
+++ b/reana-yadage-slurmcern.yaml
@@ -1,0 +1,20 @@
+version: 0.3.0
+inputs:
+  files:
+    - code/worldpopulation.ipynb
+    - data/World_historical_and_predicted_populations_in_percentage.csv
+  directories:
+    - workflow/yadage
+  parameters:
+    notebook: code/worldpopulation.ipynb
+    input_file: data/World_historical_and_predicted_populations_in_percentage.csv
+    output_file: results/plot.png
+    region: Africa
+    year_min: 1500
+    year_max: 2012
+workflow:
+  type: yadage
+  file: workflow/yadage/workflow-slurmcern.yaml
+outputs:
+  files:
+   - worldpopulation/plot.png

--- a/workflow/yadage/workflow-slurmcern.yaml
+++ b/workflow/yadage/workflow-slurmcern.yaml
@@ -1,0 +1,42 @@
+# Note that if you are working on the analysis development locally, i.e. outside
+# of the REANA platform, you can proceed as follows:
+#
+#   $ cd reana-demo-worldpopulation
+#   $ mkdir -p yadage-local-run/yadage-inputs
+#   $ cd yadage-local-run
+#   $ cp -a ../code ../data yadage-inputs
+#   $ yadage-run . ../workflow/yadage/workflow.yaml \
+#        -p notebook=code/worldpopulation.ipynb \
+#        -p input_file=data/World_historical_and_predicted_populations_in_percentage.csv \
+#        -p region=Africa \
+#        -p year_min=1500 \
+#        -p year_max=2012 \
+#        -d initdir=`pwd`/yadage-inputs
+#   $ firefox worldpopulation/plot.png
+
+stages:
+  - name: worldpopulation
+    dependencies: [init]
+    scheduler:
+      scheduler_type: 'singlestep-stage'
+      parameters:
+        notebook: {step: init, output: notebook}
+        region: {step: init, output: region}
+        year_min: {step: init, output: year_min}
+        year_max: {step: init, output: year_max}
+        input_file: {step: init, output: input_file}
+        outputfile: '{workdir}/plot.png'
+      step:
+        process:
+          process_type: 'string-interpolated-cmd'
+          cmd: 'papermill "{notebook}" /dev/null -p input_file "{input_file}" -p region "{region}" -p year_min "{year_min}" -p year_max "{year_max}" -p output_file "{outputfile}"'
+        publisher:
+          publisher_type: 'frompar-pub'
+          outputmap:
+            outputfile: outputfile
+        environment:
+          environment_type: 'docker-encapsulated'
+          image: 'reanahub/reana-env-jupyter'
+          imagetag: '1.0.0'
+          resources:
+            - compute_backend: slurmcern


### PR DESCRIPTION
Needs the same Singularity fix as in #34:

```
Auks API request failed : krb5 cred : unable to read credential cache
INFO:    Converting OCI blobs to SIF format
srun: error: hpc005: task 0: Exited with exit code 255
srun: Terminating job step 964627.0
FATAL:   Unable to handle docker://reanahub/reana-env-jupyter:1.0.0 uri: while building SIF from layers: unable to create new build: while searching for mksquashfs: exec: "mksquashfs": executable file not found in $PATH
```