### PR TITLE
snakemake: override notebook config to use py3 kernel

### DIFF
--- a/workflow/snakemake/Snakefile
+++ b/workflow/snakemake/Snakefile
@@ -8,7 +8,8 @@
 #   $ pip install snakemake papermill ipykernel pandas matplotlib
 #   $ cp -a ../code ../data .
 #   $ snakemake -s ../workflow/snakemake/Snakefile \
-#               --configfile ../workflow/snakemake/inputs.yaml -p --cores 1
+#               --configfile ../workflow/snakemake/inputs.yaml
+#               --config notebook=code/worldpopulation-py3.ipynb -p --cores 1
 #   $ open results/plot.png
 
 rule all:

--- a/workflow/snakemake/inputs.yaml
+++ b/workflow/snakemake/inputs.yaml
@@ -1,4 +1,4 @@
-notebook: code/worldpopulation-py3.ipynb
+notebook: code/worldpopulation.ipynb
 input_file: data/World_historical_and_predicted_populations_in_percentage.csv
 output_file: results/plot.png
 region: Africa


### PR DESCRIPTION
Snakemake requires Python 3 to run, so to run the example locally
we need to use a Python 3 kernel for the Jupyter notebook.