### PR TITLE
docker: podman-friendly image locations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2020, 2021 CERN.
+# Copyright (C) 2020, 2021, 2023 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -60,7 +60,7 @@ jobs:
         uses: reanahub/reana-github-actions/local-run@v1
         with:
           commands: |
-            docker run -i --rm -v `pwd`:/workdir reanahub/reana-env-jupyter:2.0.0 bash -c '
+            docker run -i --rm -v `pwd`:/workdir docker.io/reanahub/reana-env-jupyter:2.0.0 bash -c '
               cd /workdir &&
               mkdir -p ./results &&
               papermill ./code/worldpopulation.ipynb /dev/null \

--- a/README.rst
+++ b/README.rst
@@ -190,7 +190,7 @@ workflow steps and expected outputs:
       type: serial
       specification:
         steps:
-          - environment: 'reanahub/reana-env-jupyter:2.0.0'
+          - environment: 'docker.io/reanahub/reana-env-jupyter:2.0.0'
             commands:
               - mkdir -p results && papermill ${notebook} /dev/null -p input_file ${input_file} -p output_file ${output_file} -p region ${region} -p year_min ${year_min} -p year_max ${year_max}
     outputs:

--- a/reana-htcondorcern.yaml
+++ b/reana-htcondorcern.yaml
@@ -14,7 +14,7 @@ workflow:
   type: serial
   specification:
     steps:
-      - environment: 'reanahub/reana-env-jupyter:2.0.0'
+      - environment: 'docker.io/reanahub/reana-env-jupyter:2.0.0'
         compute_backend: htcondorcern
         htcondor_max_runtime: espresso
         commands:

--- a/reana-slurmcern.yaml
+++ b/reana-slurmcern.yaml
@@ -14,7 +14,7 @@ workflow:
   type: serial
   specification:
     steps:
-      - environment: 'reanahub/reana-env-jupyter:2.0.0'
+      - environment: 'docker.io/reanahub/reana-env-jupyter:2.0.0'
         compute_backend: slurmcern
         commands:
           - mkdir -p results && papermill ${notebook} /dev/null -p input_file ${input_file} -p output_file ${output_file} -p region ${region} -p year_min ${year_min} -p year_max ${year_max}

--- a/reana.yaml
+++ b/reana.yaml
@@ -14,7 +14,7 @@ workflow:
   type: serial
   specification:
     steps:
-      - environment: 'reanahub/reana-env-jupyter:2.0.0'
+      - environment: 'docker.io/reanahub/reana-env-jupyter:2.0.0'
         commands:
           - mkdir -p results && papermill ${notebook} /dev/null -p input_file ${input_file} -p output_file ${output_file} -p region ${region} -p year_min ${year_min} -p year_max ${year_max}
 outputs:

--- a/workflow/cwl/worldpopulation.tool
+++ b/workflow/cwl/worldpopulation.tool
@@ -6,7 +6,7 @@ class: CommandLineTool
 requirements:
   - class: InlineJavascriptRequirement
   - class: DockerRequirement
-    dockerPull: reanahub/reana-env-jupyter:2.0.0
+    dockerPull: docker.io/reanahub/reana-env-jupyter:2.0.0
 
 baseCommand: ["papermill"]
 

--- a/workflow/snakemake/Snakefile
+++ b/workflow/snakemake/Snakefile
@@ -28,7 +28,7 @@ rule worldpopulation:
     output:
         output_file=config["output_file"]
     container:
-        "docker://reanahub/reana-env-jupyter:2.0.0"
+        "docker://docker.io/reanahub/reana-env-jupyter:2.0.0"
     shell:
         "mkdir -p results && papermill {input.notebook} /dev/null -p "
         "input_file {input.input_file} -p output_file {output.output_file} "

--- a/workflow/snakemake/Snakefile-htcondorcern
+++ b/workflow/snakemake/Snakefile-htcondorcern
@@ -17,7 +17,7 @@ rule worldpopulation:
     output:
         output_file=config["output_file"]
     container:
-        "docker://reanahub/reana-env-jupyter:2.0.0"
+        "docker://docker.io/reanahub/reana-env-jupyter:2.0.0"
     shell:
         "mkdir -p results && papermill {input.notebook} /dev/null -p "
         "input_file {input.input_file} -p output_file {output.output_file} "

--- a/workflow/snakemake/Snakefile-slurmcern
+++ b/workflow/snakemake/Snakefile-slurmcern
@@ -16,7 +16,7 @@ rule worldpopulation:
     output:
         output_file=config["output_file"]
     container:
-        "docker://reanahub/reana-env-jupyter:2.0.0"
+        "docker://docker.io/reanahub/reana-env-jupyter:2.0.0"
     shell:
         "mkdir -p results && papermill {input.notebook} /dev/null -p "
         "input_file {input.input_file} -p output_file {output.output_file} "

--- a/workflow/yadage/workflow-htcondorcern.yaml
+++ b/workflow/yadage/workflow-htcondorcern.yaml
@@ -36,7 +36,7 @@ stages:
             outputfile: outputfile
         environment:
           environment_type: 'docker-encapsulated'
-          image: 'reanahub/reana-env-jupyter'
+          image: 'docker.io/reanahub/reana-env-jupyter'
           imagetag: '2.0.0'
           resources:
             - compute_backend: htcondorcern

--- a/workflow/yadage/workflow-slurmcern.yaml
+++ b/workflow/yadage/workflow-slurmcern.yaml
@@ -36,7 +36,7 @@ stages:
             outputfile: outputfile
         environment:
           environment_type: 'docker-encapsulated'
-          image: 'reanahub/reana-env-jupyter'
+          image: 'docker.io/reanahub/reana-env-jupyter'
           imagetag: '2.0.0'
           resources:
             - compute_backend: slurmcern

--- a/workflow/yadage/workflow.yaml
+++ b/workflow/yadage/workflow.yaml
@@ -36,5 +36,5 @@ stages:
             outputfile: outputfile
         environment:
           environment_type: 'docker-encapsulated'
-          image: 'reanahub/reana-env-jupyter'
+          image: 'docker.io/reanahub/reana-env-jupyter'
           imagetag: '2.0.0'


### PR DESCRIPTION
Adds fully qualified canonical locations of container images, making the container technology setup podman-friendly.

Closes reanahub/reana#729.