### PR TITLE
fix(tests): increase workspace size upper bound

### DIFF
--- a/tests/serial/workspace-files.feature
+++ b/tests/serial/workspace-files.feature
@@ -20,4 +20,4 @@ Feature: Workspace files
     Scenario: The total workspace size remains within reasonable limits
         When the workflow is finished
         Then the workspace size should be more than 20KiB
-        And the workspace size should be less than 60KiB
+        And the workspace size should be less than 85KiB

--- a/tests/yadage/workspace-files.feature
+++ b/tests/yadage/workspace-files.feature
@@ -20,4 +20,4 @@ Feature: Workspace files
     Scenario: The total workspace size remains within reasonable limits
         When the workflow is finished
         Then the workspace size should be more than 200KiB
-        And the workspace size should be less than 400KiB
+        And the workspace size should be less than 450KiB


### PR DESCRIPTION
This PR slightly increases the upper bound on the 'reasonable workspace size' for Yadage and Serial.