### PR TITLE
fix(git): ignore Snakemake runtime directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-results/
+.snakemake/
 code/.ipynb_checkpoints
+results/


### PR DESCRIPTION
Exclude the .snakemake directory created during local workflow
execution. Snakemake uses it to store runtime state, metadata, locks,
logs and other machine-local files.

Keep local workflow runs from showing up as untracked repository
changes.
