### PR TITLE
feat(workflow): declare shared CWL tool file

### DIFF
--- a/reana-cwl-htcondorcern.yaml
+++ b/reana-cwl-htcondorcern.yaml
@@ -10,6 +10,8 @@ inputs:
 workflow:
   type: cwl
   file: workflow/cwl/worldpopulation-htcondorcern.cwl
+  files:
+    - workflow/cwl/worldpopulation.tool
 outputs:
   files:
     - outputs/plot.png

--- a/reana-cwl-slurmcern.yaml
+++ b/reana-cwl-slurmcern.yaml
@@ -10,6 +10,8 @@ inputs:
 workflow:
   type: cwl
   file: workflow/cwl/worldpopulation-slurmcern.cwl
+  files:
+    - workflow/cwl/worldpopulation.tool
 outputs:
   files:
     - outputs/plot.png

--- a/reana-cwl.yaml
+++ b/reana-cwl.yaml
@@ -10,6 +10,8 @@ inputs:
 workflow:
   type: cwl
   file: workflow/cwl/worldpopulation.cwl
+  files:
+    - workflow/cwl/worldpopulation.tool
 outputs:
   files:
     - outputs/plot.png


### PR DESCRIPTION
Add worldpopulation.tool to workflow.files in all three CWL variants
so that new REANA clients using server-side workflow loading and
validation include it in the workflow specification bundle.

The existing inputs.directories entries keep this file available to
older REANA clients and servers.

Closes reanahub/reana-workflow-validator#8